### PR TITLE
Fix typo 'paramter_name' in whatsapp message

### DIFF
--- a/utils.gs
+++ b/utils.gs
@@ -77,7 +77,7 @@ function sendWhatsAppMsg(person) {
           parameters: [
             {
               type: "text",
-              paramter_name: "role",
+              parameter_name: "role",
               text: person.role,
             },
           ],
@@ -87,7 +87,7 @@ function sendWhatsAppMsg(person) {
           parameters: [
             {
               type: "text",
-              paramter_name: "name",
+              parameter_name: "name",
               text: person.name,
             },
             {


### PR DESCRIPTION
### Why

To fix error 'Unexpected key error'
```
Request failed for https://graph.facebook.com returned code 400. Truncated server response: {"error":{"message":"(#100) Unexpected key \"paramter_name\" on param \"template['components'][0]['parameters'][0]\".","type":"OAuthException","cod... (use muteHttpExceptions option to examine full response)
```

### What was done

- Renamed 'paramter_name' to the right property 'parameter_name'